### PR TITLE
6주차 미션 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,13 +27,42 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'io.github.openfeign.querydsl:querydsl-jpa:7.0'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+
+    // QueryDSL : OpenFeign
+    implementation "io.github.openfeign.querydsl:querydsl-jpa:7.0"
+    implementation "io.github.openfeign.querydsl:querydsl-core:7.0"
+    annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:7.0:jpa"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+
+// QueryDSL 관련 설정
+// generated/querydsl 폴더 생성 & 삽입
+def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
+
+// 소스 세트에 생성 경로 추가 (구체적인 경로 지정)
+sourceSets {
+    main.java.srcDirs += [ querydslDir ]
+}
+
+// 컴파일 시 생성 경로 지정
+tasks.withType(JavaCompile).configureEach {
+    options.generatedSourceOutputDirectory.set(querydslDir)
+}
+
+// clean 태스크에 생성 폴더 삭제 로직 추가
+clean.doLast {
+    file(querydslDir).deleteDir()
 }

--- a/src/main/java/com/example/umc9th/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/umc9th/domain/review/controller/ReviewController.java
@@ -1,14 +1,14 @@
 package com.example.umc9th.domain.review.controller;
 
 
+import com.example.umc9th.domain.review.dto.ReviewResponse;
+import com.example.umc9th.domain.review.entity.Review;
 import com.example.umc9th.domain.review.service.ReviewService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/reviews")
@@ -31,5 +31,16 @@ public class ReviewController {
         public CreateReviewRequest() {}
         public String getContent() { return content; }
         public Float getRate() { return rate; }
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<List<ReviewResponse>> getReviews(
+            @RequestParam String query,
+            @RequestParam String type) {
+        List<Review> reviews = reviewService.searchReviews(query, type);
+        List<ReviewResponse> body = reviews.stream()
+                .map(ReviewResponse::from)
+                .toList();
+        return ResponseEntity.ok(body);
     }
 }

--- a/src/main/java/com/example/umc9th/domain/review/dto/ReviewResponse.java
+++ b/src/main/java/com/example/umc9th/domain/review/dto/ReviewResponse.java
@@ -1,0 +1,21 @@
+package com.example.umc9th.domain.review.dto;
+
+import com.example.umc9th.domain.review.entity.Review;
+
+public record ReviewResponse(
+        Long id,
+        String content,
+        Float rate,
+        Long memberId,
+        Long storeId
+) {
+    public static ReviewResponse from(Review r) {
+        return new ReviewResponse(
+                r.getId(),
+                r.getContent(),
+                r.getRate(),
+                r.getMember() != null ? r.getMember().getId() : null,
+                r.getStore() != null ? r.getStore().getId() : null
+        );
+    }
+}

--- a/src/main/java/com/example/umc9th/domain/review/repository/ReviewQueryDsl.java
+++ b/src/main/java/com/example/umc9th/domain/review/repository/ReviewQueryDsl.java
@@ -1,0 +1,15 @@
+package com.example.umc9th.domain.review.repository;
+
+import com.example.umc9th.domain.review.entity.Review;
+import com.querydsl.core.types.Predicate;
+
+import java.util.List;
+
+public interface ReviewQueryDsl {
+
+    //검색 API
+    List<Review> searchReview(
+            Predicate predicate
+    );
+
+}

--- a/src/main/java/com/example/umc9th/domain/review/repository/ReviewQueryDslImpl.java
+++ b/src/main/java/com/example/umc9th/domain/review/repository/ReviewQueryDslImpl.java
@@ -1,0 +1,35 @@
+package com.example.umc9th.domain.review.repository;
+
+
+import com.example.umc9th.domain.review.entity.QReview;
+import com.example.umc9th.domain.review.entity.Review;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewQueryDslImpl implements ReviewQueryDsl{
+    private final EntityManager em;
+
+    //검색 API
+    @Override
+    public List<Review> searchReview(
+            Predicate predicate
+    ){
+        //JPA 세팅
+        JPAQueryFactory queryFactory = new JPAQueryFactory(em);
+
+        //Q클래스 선언
+        QReview review = QReview.review;
+
+        return queryFactory
+                .selectFrom(review)
+                .where(predicate)
+                .fetch();
+    }
+}

--- a/src/main/java/com/example/umc9th/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/umc9th/domain/review/repository/ReviewRepository.java
@@ -3,5 +3,5 @@ package com.example.umc9th.domain.review.repository;
 import com.example.umc9th.domain.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ReviewRepository extends JpaRepository<Review, Long> {
+public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewQueryDsl {
 }

--- a/src/main/java/com/example/umc9th/domain/review/service/ReviewService.java
+++ b/src/main/java/com/example/umc9th/domain/review/service/ReviewService.java
@@ -1,14 +1,18 @@
 package com.example.umc9th.domain.review.service;
 
+import com.example.umc9th.domain.review.entity.QReview;
 import com.example.umc9th.domain.review.entity.Review;
 import com.example.umc9th.domain.review.repository.ReviewRepository;
 import com.example.umc9th.domain.store.entity.Store;
 import com.example.umc9th.domain.store.repository.StoreRepository;
 import com.example.umc9th.domain.member.entity.Member;
 import com.example.umc9th.domain.member.repository.MemberRepository;
+import com.querydsl.core.BooleanBuilder;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -41,4 +45,44 @@ public class ReviewService {
 
         return reviewRepository.save(review).getId();
     }
+
+    @Transactional
+    public List<Review> searchReviews(String query, String type) {
+
+        //Q클래스 정의
+        QReview review = QReview.review;
+
+        //BooleanBuilder 정의
+        BooleanBuilder builder = new BooleanBuilder();
+
+        //BooleanBuilder 사용
+
+        //동적 쿼리: 검색 조건
+        if(type.equals("region")) {
+            builder.and(review.store.region.name.contains(query));
+        }
+        if(type.equals("rate")) {
+            builder.and(review.rate.goe(Float.parseFloat(query)));
+        }
+        if(type.equals("both")){
+
+            // & 기준 변환
+            String firstQuery = query.split("&")[0];
+            String secondQuery = query.split("&")[1];
+
+            //firstQuery, secondQuery 로그 출력
+            System.out.println("firstQuery: " + firstQuery);
+            System.out.println("secondQuery: " + secondQuery);
+
+            //동적 쿼리
+            builder.and(review.store.region.name.contains(firstQuery));
+            builder.and(review.rate.goe(Float.parseFloat(secondQuery)));
+
+
+
+        }
+        List<Review> reviewList = reviewRepository.searchReview(builder);
+        return reviewList;
+    }
+
 }


### PR DESCRIPTION
## 📝 작업 내용
- build.gradle에 QueryDSL(openfeign) 의존성 추가
- 지역, 평점을 기반으로 리뷰를 필터링하는 api 구현(유저 id에 따른 필터링은 추후 추가 예정)
- review.dto에 ReviewRequest 정의 후 위의 api에 적용

## 🔍 관련 이슈
- Close #5 

## 🖼️ 스크린샷 
* POSTMAN
<img width="964" height="895" alt="{86EFE7E0-0C5E-45BA-B758-0C63571CE430}" src="https://github.com/user-attachments/assets/e1c931ce-2566-4683-94eb-746a6f506d42" />

* query 파싱, sql문
<img width="443" height="642" alt="{837AAB2E-D589-48A4-99B3-5B8C0B2ADF2E}" src="https://github.com/user-attachments/assets/0d244fa9-2454-47de-bca2-bfbc172c2d54" />


## 💬 기타 참고 사항

<img width="893" height="63" alt="{E1FD0823-362E-4D39-8B13-8BCB764ECD5C}" src="https://github.com/user-attachments/assets/2c9c4b87-391d-43dc-a85b-63ae5bd62168" />
- 첫 번째 &는 쿼리 파라미터 구분자임(type=both 와 query=...를 구분). 인코딩하면 파라미터가 분리되지 않아 잘못됨.
두 번째 &는 query 값 내부에서 두 값을 묶기 위한 데이터 그 자체이므로, 구분자로 오해되지 않게 %26으로 인코딩해야 함.
서버 도착 시 %26 → &로 디코딩되어 서비스에서 query.split("&")가 정상 동작함.
참고로 한글 서울도 URL 규격상 퍼센트 인코딩 대상이지만, 브라우저/클라이언트가 보통 자동 인코딩함